### PR TITLE
Rename the connectionTimeoutSec option to executionTimeoutSec

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The tool has almost all the features the DbUp has, but without a single line of 
 
 |Date|Version|Description|
 |-|-|-|
-|2020-03-20|1.2.0|Add a connectionTimeoutSec option
+|2020-03-20|1.2.0|Add an executionTimeoutSec option
 |2019-08-27|1.1.2|Minor fixes
 |2019-04-11|1.1.0|PostgreSQL support
 |2019-03-25|1.0.1|Initial version (DbUp 4.2)

--- a/src/dbup-cli.integration-tests/PostgreSqlTests.cs
+++ b/src/dbup-cli.integration-tests/PostgreSqlTests.cs
@@ -102,7 +102,7 @@ namespace DbUp.Cli.IntegrationTests
         }
 
         [TestMethod]
-        public void UpgradeCommand_ShouldUseConnectionTimeoutForLongrunningQueries()
+        public void UpgradeCommand_ShouldUseExecutionTimeoutForLongrunningQueries()
         {
             var engine = new ToolEngine(Env, Logger);
 

--- a/src/dbup-cli.integration-tests/Scripts/PostgreSql/Timeout/dbup.yml
+++ b/src/dbup-cli.integration-tests/Scripts/PostgreSql/Timeout/dbup.yml
@@ -2,4 +2,4 @@ dbUp:
   version: 1                    # should be 1
   provider: postgresql          # DB provider: sqlserver
   connectionString: $CONNSTR$   # Connection string to DB. For example, "Data Source=(localdb)\dbup;Initial Catalog=MyDb;Integrated Security=True" for sqlserver
-  connectionTimeoutSec: 10      # Connection timeout in seconds
+  executionTimeoutSec: 10       # Connection timeout in seconds

--- a/src/dbup-cli.integration-tests/Scripts/SqlServer/Timeout/dbup.yml
+++ b/src/dbup-cli.integration-tests/Scripts/SqlServer/Timeout/dbup.yml
@@ -2,4 +2,4 @@ dbUp:
   version: 1                    # should be 1
   provider: sqlserver           # DB provider: sqlserver
   connectionString: $CONNSTR$   # Connection string to DB. For example, "Data Source=(localdb)\dbup;Initial Catalog=MyDb;Integrated Security=True" for sqlserver
-  connectionTimeoutSec: 10      # Connection timeout in seconds
+  executionTimeoutSec: 10       # Connection timeout in seconds

--- a/src/dbup-cli.integration-tests/SqlServerTests.cs
+++ b/src/dbup-cli.integration-tests/SqlServerTests.cs
@@ -99,7 +99,7 @@ namespace DbUp.Cli.IntegrationTests
         }
 
         [TestMethod]
-        public void UpgradeCommand_ShouldUseConnectionTimeoutForLongrunningQueries()
+        public void UpgradeCommand_ShouldUseExecutionTimeoutForLongrunningQueries()
         {
             var engine = new ToolEngine(Env, Logger);
 

--- a/src/dbup-cli.tests/ConfigLoaderTests.cs
+++ b/src/dbup-cli.tests/ConfigLoaderTests.cs
@@ -37,7 +37,7 @@ namespace DbUp.Cli.Tests
             migration.MatchSome(x =>
             {
                 x.Transaction.Should().Be(Transaction.None);
-                x.ConnectionTimeoutSec.Should().Be(30);
+                x.ExecutionTimeoutSec.Should().Be(30);
 
                 x.Scripts.Should().HaveCount(1);
                 x.Scripts[0].Encoding.Should().Be(Constants.Default.Encoding);
@@ -77,7 +77,7 @@ namespace DbUp.Cli.Tests
 
             migration.MatchSome(x =>
             {
-                x.ConnectionTimeoutSec.Should().Be(45);
+                x.ExecutionTimeoutSec.Should().Be(45);
             });
         }
 

--- a/src/dbup-cli.tests/Scripts/Config/timeout.yml
+++ b/src/dbup-cli.tests/Scripts/Config/timeout.yml
@@ -2,4 +2,4 @@ dbUp:
   version: 1
   provider: sqlserver
   connectionString: (localdb)\dbup;Initial Catalog=DbUpTest;Integrated Security=True
-  connectionTimeoutSec: 45
+  executionTimeoutSec: 45

--- a/src/dbup-cli/ConfigFile/Migration.cs
+++ b/src/dbup-cli/ConfigFile/Migration.cs
@@ -9,7 +9,7 @@ namespace DbUp.Cli
         public string Version { get; private set; }
         public Provider Provider { get; private set; }
         public string ConnectionString { get; private set; }
-        public int ConnectionTimeoutSec { get; private set; } = 30;
+        public int ExecutionTimeoutSec { get; private set; } = 30;
         public Transaction Transaction { get; private set; } = Transaction.None;
         public Option<Journal> JournalTo { get; private set; } = Journal.Default.Some();
 

--- a/src/dbup-cli/ConfigurationHelper.cs
+++ b/src/dbup-cli/ConfigurationHelper.cs
@@ -12,31 +12,31 @@ namespace DbUp.Cli
 {
     public static class ConfigurationHelper
     {
-        public static Option<UpgradeEngineBuilder, Error> SelectDbProvider(Provider provider, string connectionString, int connectionTimeoutSec)
+        public static Option<UpgradeEngineBuilder, Error> SelectDbProvider(Provider provider, string connectionString, int executionTimeoutSec)
         {
             switch (provider)
             {
                 case Provider.SqlServer:
                     return DeployChanges.To.SqlDatabase(connectionString)
-                        .WithExecutionTimeout(TimeSpan.FromSeconds(connectionTimeoutSec))
+                        .WithExecutionTimeout(TimeSpan.FromSeconds(executionTimeoutSec))
                         .Some<UpgradeEngineBuilder, Error>();
                 case Provider.PostgreSQL:
                     return DeployChanges.To.PostgresqlDatabase(connectionString)
-                        .WithExecutionTimeout(TimeSpan.FromSeconds(connectionTimeoutSec))
+                        .WithExecutionTimeout(TimeSpan.FromSeconds(executionTimeoutSec))
                         .Some<UpgradeEngineBuilder, Error>();
             }
 
             return Option.None<UpgradeEngineBuilder, Error>(Error.Create(Constants.ConsoleMessages.UnsupportedProvider, provider.ToString()));
         }
 
-        public static Option<bool, Error> EnsureDb(IUpgradeLog logger, Provider provider, string connectionString, int connectionTimeoutSec)
+        public static Option<bool, Error> EnsureDb(IUpgradeLog logger, Provider provider, string connectionString, int executionTimeoutSec)
         {
             try
             {
                 switch (provider)
                 {
                     case Provider.SqlServer:
-                        EnsureDatabase.For.SqlDatabase(connectionString, logger, timeout: connectionTimeoutSec);
+                        EnsureDatabase.For.SqlDatabase(connectionString, logger, timeout: executionTimeoutSec);
                         return true.Some<bool, Error>();
                     case Provider.PostgreSQL:
                         EnsureDatabase.For.PostgresqlDatabase(connectionString, logger); // Postgres provider does not support timeout...
@@ -51,14 +51,14 @@ namespace DbUp.Cli
             return Option.None<bool, Error>(Error.Create(Constants.ConsoleMessages.UnsupportedProvider, provider.ToString()));
         }
 
-        public static Option<bool, Error> DropDb(IUpgradeLog logger, Provider provider, string connectionString, int connectionTimeoutSec)
+        public static Option<bool, Error> DropDb(IUpgradeLog logger, Provider provider, string connectionString, int executionTimeoutSec)
         {
             try
             {
                 switch (provider)
                 {
                     case Provider.SqlServer:
-                        DropDatabase.For.SqlDatabase(connectionString, logger, timeout: connectionTimeoutSec);
+                        DropDatabase.For.SqlDatabase(connectionString, logger, timeout: executionTimeoutSec);
                         return true.Some<bool, Error>();
                     case Provider.PostgreSQL:
                         return Option.None<bool, Error>(Error.Create("PostgreSQL database provider does not support 'drop' command for now"));

--- a/src/dbup-cli/DefaultOptions/dbup.yml
+++ b/src/dbup-cli/DefaultOptions/dbup.yml
@@ -2,7 +2,7 @@ dbUp:
   version: 1                    # should be 1
   provider: sqlserver           # DB provider: sqlserver
   connectionString: $CONNSTR$   # Connection string to DB. For example, "Data Source=(localdb)\dbup;Initial Catalog=MyDb;Integrated Security=True" for sqlserver
-  connectionTimeoutSec: 30      # Connection timeout in seconds
+  executionTimeoutSec: 30       # Execution timeout in seconds
   transaction: None             # Single / PerScript / None (default)
   scripts:
     -   folder:                 # absolute or relative (to this file) path to a folder with *.sql files

--- a/src/dbup-cli/ToolEngine.cs
+++ b/src/dbup-cli/ToolEngine.cs
@@ -58,7 +58,7 @@ namespace DbUp.Cli
                         .Match(
                             some: x =>
                                 ConfigurationHelper
-                                    .SelectDbProvider(x.Provider, x.ConnectionString, x.ConnectionTimeoutSec)
+                                    .SelectDbProvider(x.Provider, x.ConnectionString, x.ExecutionTimeoutSec)
                                     .SelectJournal(x.JournalTo)
                                     .SelectTransaction(x.Transaction)
                                     .SelectLogOptions(Logger, VerbosityLevel.Min)
@@ -139,7 +139,7 @@ namespace DbUp.Cli
                         .Match(
                             some: x =>
                                 ConfigurationHelper
-                                    .SelectDbProvider(x.Provider, x.ConnectionString, x.ConnectionTimeoutSec)
+                                    .SelectDbProvider(x.Provider, x.ConnectionString, x.ExecutionTimeoutSec)
                                     .SelectJournal(x.JournalTo)
                                     .SelectTransaction(x.Transaction)
                                     .SelectLogOptions(Logger, opts.Verbosity)
@@ -152,7 +152,7 @@ namespace DbUp.Cli
                                         var engine = builder.Build();
                                         if (opts.Ensure)
                                         {
-                                            var res = ConfigurationHelper.EnsureDb(Logger, x.Provider, x.ConnectionString, x.ConnectionTimeoutSec);
+                                            var res = ConfigurationHelper.EnsureDb(Logger, x.Provider, x.ConnectionString, x.ExecutionTimeoutSec);
                                             if (!res.HasValue)
                                             {
                                                 Error err = null;
@@ -186,7 +186,7 @@ namespace DbUp.Cli
                         .Match(
                             some: x =>
                                 ConfigurationHelper
-                                    .SelectDbProvider(x.Provider, x.ConnectionString, x.ConnectionTimeoutSec)
+                                    .SelectDbProvider(x.Provider, x.ConnectionString, x.ExecutionTimeoutSec)
                                     .SelectJournal(x.JournalTo)
                                     .SelectTransaction(x.Transaction)
                                     .SelectLogOptions(Logger, opts.Verbosity)
@@ -199,7 +199,7 @@ namespace DbUp.Cli
                                         var engine = builder.Build();
                                         if (opts.Ensure)
                                         {
-                                            var res = ConfigurationHelper.EnsureDb(Logger, x.Provider, x.ConnectionString, x.ConnectionTimeoutSec);
+                                            var res = ConfigurationHelper.EnsureDb(Logger, x.Provider, x.ConnectionString, x.ExecutionTimeoutSec);
                                             if (!res.HasValue)
                                             {
                                                 Error err = null;
@@ -233,13 +233,13 @@ namespace DbUp.Cli
                         .Match(
                             some: x =>
                                 ConfigurationHelper
-                                    .SelectDbProvider(x.Provider, x.ConnectionString, x.ConnectionTimeoutSec)
+                                    .SelectDbProvider(x.Provider, x.ConnectionString, x.ExecutionTimeoutSec)
                                     .SelectLogOptions(Logger, opts.Verbosity)
                                     .OverrideConnectionFactory(ConnectionFactory)
                                 .Match(
                                     some: builder =>
                                     {
-                                        var res = ConfigurationHelper.DropDb(Logger, x.Provider, x.ConnectionString, x.ConnectionTimeoutSec);
+                                        var res = ConfigurationHelper.DropDb(Logger, x.Provider, x.ConnectionString, x.ExecutionTimeoutSec);
                                         if (!res.HasValue)
                                         {
                                             Error err = null;

--- a/src/dbup-cli/dbup-cli.csproj
+++ b/src/dbup-cli/dbup-cli.csproj
@@ -20,7 +20,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dbup</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <PackageReleaseNotes>1.2.0 Add a connectionTimeoutSec option to dbup.yml
+    <PackageReleaseNotes>1.2.0 Add an executionTimeoutSec option to dbup.yml
 1.1.2 Minor fixes
 1.1.0 PostgreSQL support
 1.0.1 Initial version (DbUp 4.2)</PackageReleaseNotes>


### PR DESCRIPTION
Because it is an execution timeout in fact. "connectionTimeoutSec" name is wrong and can be misleading.
Another appropriate name considered is "commandTimeoutSec".

Note:
1. `dbup-cli.tests` are passed;
2. `dbup-cli.integration-tests`: everything is passed except that the `UpgradeCommand_ShouldUseExecutionTimeoutForLongrunningQueries()` for SqlServer test is failed for the first time usually;
3. Maybe the version number should be changed to 1.2.1.